### PR TITLE
Arduino Leonardo support

### DIFF
--- a/sw/pp3.c
+++ b/sw/pp3.c
@@ -320,6 +320,14 @@ void sleep_ms (int num)
     nanosleep(&tspec,0);
     }
 
+void sleep_us (int num)
+    {
+    struct timespec tspec;
+    tspec.tv_sec=num/1000000;
+    tspec.tv_nsec=(num%1000000)*1000;
+    nanosleep(&tspec,0);
+    }
+
 void printHelp()
     {
     flsprintf(stdout,"pp programmer\n");
@@ -704,7 +712,12 @@ int p18a_write_page (unsigned char * data, int address, unsigned char num)
     putByte((address>>8)&0xFF);
     putByte((address>>0)&0xFF);
     for (i=0; i<num; i++)
+        {
         putByte(data[i]);
+
+        // Without this delay Arduino Leonardo's USB serial might be stalled
+        sleep_us(5);
+        }
     getByte();
     return 0;
     }

--- a/sw/pp3.c
+++ b/sw/pp3.c
@@ -112,11 +112,11 @@ void putBytes (unsigned char * data, int len)
     for (i=0; i<len; i++)
         putByte(data[i]);
     /*
-    	if (verbose>3)
-    		flsprintf(stdout,"TXP: %d B\n", len);
+        if (verbose>3)
+            flsprintf(stdout,"TXP: %d B\n", len);
     int n = write(com, data, len);
-    	if (n != len)
-    		comErr("Serial port failed to send %d bytes, write returned %d\n", len,n);
+        if (n != len)
+            comErr("Serial port failed to send %d bytes, write returned %d\n", len,n);
     */
     }
 
@@ -200,7 +200,7 @@ void putBytes (unsigned char * data, int len)
     /*
     int i;
     for (i=0;i<len;i++)
-    	putByte(data[i]);
+        putByte(data[i]);
     */
     int n;
     WriteFile(port_handle, data, len, (LPDWORD)((void *)&n), NULL);
@@ -417,59 +417,59 @@ int setCPUtype(char* cpu)
         {
         if (verbose>3) printf("\nRead %d chars: %s",read,line);
         if (line[0]!='#')
-			{
-			sscanf (line,"%s %d %d %x %x %s",(char*)&read_cpu_type,&read_flash_size,&read_page_size,&read_id,&read_mask,(char*)&read_algo_type);
-			if (verbose>3) printf("\n*** %s,%d,%d,%x,%x,%s",read_cpu_type,read_flash_size,read_page_size,read_id,read_mask,read_algo_type);
-			if (strcmp(read_cpu_type,cpu)==0)
-				{
-				flash_size = read_flash_size;
-				page_size = read_page_size;
-				devid_expected = read_id;
-				devid_mask = read_mask;
-				if (verbose>1) printf("Found database match %s,%d,%d,%x,%x,%s\n",read_cpu_type,read_flash_size,read_page_size,read_id,read_mask,read_algo_type);
-				if (strcmp("CF_P16F_A",read_algo_type)==0) chip_family = CF_P16F_A;
-				if (strcmp("CF_P16F_B",read_algo_type)==0) chip_family = CF_P16F_B;
-				if (strcmp("CF_P16F_C",read_algo_type)==0) chip_family = CF_P16F_C;
-				if (strcmp("CF_P16F_D",read_algo_type)==0) chip_family = CF_P16F_D;
-				if (strcmp("CF_P18F_A",read_algo_type)==0) chip_family = CF_P18F_A;
-				if (strcmp("CF_P18F_B",read_algo_type)==0) chip_family = CF_P18F_B;
-				if (strcmp("CF_P18F_C",read_algo_type)==0) chip_family = CF_P18F_C;
-				if (strcmp("CF_P18F_D",read_algo_type)==0) chip_family = CF_P18F_D;
-				if (strcmp("CF_P18F_E",read_algo_type)==0) chip_family = CF_P18F_E;
-				if (strcmp("CF_P18F_F",read_algo_type)==0) chip_family = CF_P18F_F;
-				if (strcmp("CF_P18F_G",read_algo_type)==0) chip_family = CF_P18F_G;
-				if (strcmp("CF_P18F_Q",read_algo_type)==0) chip_family = CF_P18F_Q;
-				if (strcmp("CF_P18F_Q43",read_algo_type)==0) chip_family = CF_P18F_Q43;
-				if (strcmp("CF_P18F_Q8x",read_algo_type)==0) chip_family = CF_P18F_Q8x;
-				if (chip_family == CF_P18F_A) config_size = 16;
-				if (chip_family == CF_P18F_B) config_size = 8;
-				if (chip_family == CF_P18F_C) 
-					{
-						config_size = 16;
-						chip_family = CF_P18F_B;
-					}
-				if (chip_family == CF_P18F_D) config_size = 16;
-				if (chip_family == CF_P18F_E) config_size = 16;
-				if (chip_family == CF_P18F_F) config_size = 12;
-				if (chip_family == CF_P18F_Q) config_size = 12;
-				if (chip_family == CF_P18F_G) 
-					{
-						config_size = 10;
-						chip_family = CF_P18F_F;
-					}				
-				if (chip_family == CF_P18F_Q43)
-					{
-						config_size = 10;
-						chip_family = CF_P18F_Qxx;
-					}
-				if (chip_family == CF_P18F_Q8x)
-					{
-						config_size = 35;
-						chip_family = CF_P18F_Qxx;
-					}
-				if (verbose>2) printf("chip family:%d, config size:%d\n",chip_family,config_size);
-				}
-			}
+            {
+            sscanf (line,"%s %d %d %x %x %s",(char*)&read_cpu_type,&read_flash_size,&read_page_size,&read_id,&read_mask,(char*)&read_algo_type);
+            if (verbose>3) printf("\n*** %s,%d,%d,%x,%x,%s",read_cpu_type,read_flash_size,read_page_size,read_id,read_mask,read_algo_type);
+            if (strcmp(read_cpu_type,cpu)==0)
+                {
+                flash_size = read_flash_size;
+                page_size = read_page_size;
+                devid_expected = read_id;
+                devid_mask = read_mask;
+                if (verbose>1) printf("Found database match %s,%d,%d,%x,%x,%s\n",read_cpu_type,read_flash_size,read_page_size,read_id,read_mask,read_algo_type);
+                if (strcmp("CF_P16F_A",read_algo_type)==0) chip_family = CF_P16F_A;
+                if (strcmp("CF_P16F_B",read_algo_type)==0) chip_family = CF_P16F_B;
+                if (strcmp("CF_P16F_C",read_algo_type)==0) chip_family = CF_P16F_C;
+                if (strcmp("CF_P16F_D",read_algo_type)==0) chip_family = CF_P16F_D;
+                if (strcmp("CF_P18F_A",read_algo_type)==0) chip_family = CF_P18F_A;
+                if (strcmp("CF_P18F_B",read_algo_type)==0) chip_family = CF_P18F_B;
+                if (strcmp("CF_P18F_C",read_algo_type)==0) chip_family = CF_P18F_C;
+                if (strcmp("CF_P18F_D",read_algo_type)==0) chip_family = CF_P18F_D;
+                if (strcmp("CF_P18F_E",read_algo_type)==0) chip_family = CF_P18F_E;
+                if (strcmp("CF_P18F_F",read_algo_type)==0) chip_family = CF_P18F_F;
+                if (strcmp("CF_P18F_G",read_algo_type)==0) chip_family = CF_P18F_G;
+                if (strcmp("CF_P18F_Q",read_algo_type)==0) chip_family = CF_P18F_Q;
+                if (strcmp("CF_P18F_Q43",read_algo_type)==0) chip_family = CF_P18F_Q43;
+                if (strcmp("CF_P18F_Q8x",read_algo_type)==0) chip_family = CF_P18F_Q8x;
+                if (chip_family == CF_P18F_A) config_size = 16;
+                if (chip_family == CF_P18F_B) config_size = 8;
+                if (chip_family == CF_P18F_C)
+                    {
+                        config_size = 16;
+                        chip_family = CF_P18F_B;
+                    }
+                if (chip_family == CF_P18F_D) config_size = 16;
+                if (chip_family == CF_P18F_E) config_size = 16;
+                if (chip_family == CF_P18F_F) config_size = 12;
+                if (chip_family == CF_P18F_Q) config_size = 12;
+                if (chip_family == CF_P18F_G)
+                    {
+                        config_size = 10;
+                        chip_family = CF_P18F_F;
+                    }
+                if (chip_family == CF_P18F_Q43)
+                    {
+                        config_size = 10;
+                        chip_family = CF_P18F_Qxx;
+                    }
+                if (chip_family == CF_P18F_Q8x)
+                    {
+                        config_size = 35;
+                        chip_family = CF_P18F_Qxx;
+                    }
+                if (verbose>2) printf("chip family:%d, config size:%d\n",chip_family,config_size);
+                }
+            }
         }
     fclose(sf);
 
@@ -486,9 +486,9 @@ int p16a_rst_pointer (void)
     {
     if (verbose>2) flsprintf(stdout,"Resetting PC\n");
     if (chip_family==CF_P16F_D)
-		putByte(0x09);					//operation number
-	else
-		putByte(0x03);					//operation number	
+        putByte(0x09);					//operation number
+    else
+        putByte(0x03);					//operation number
     putByte(0x00);					//number of bytes remaining
     getByte();						//return result - no check for its value
     return 0;
@@ -532,8 +532,8 @@ int p16a_program_page (unsigned int ptr, unsigned char num, unsigned char slow)
     putByte(slow);
     /*
     for (i=0;i<num;i++)
-    	putByte(file_image[ptr+i]);
-    	*/
+        putByte(file_image[ptr+i]);
+        */
     putBytes(&file_image[ptr],num);
     getByte();
     return 0;
@@ -633,54 +633,54 @@ int p18b_mass_erase (void)
     }
 
 int p18d_mass_erase_part (unsigned long data)
-	{
-	if (verbose>2) flsprintf(stdout,"Mass erase part of 0x%6.6x\n",data);
+    {
+    if (verbose>2) flsprintf(stdout,"Mass erase part of 0x%6.6x\n",data);
     putByte(0x30);
     putByte(0x03);
     putByte((data>>16)&0xFF);
     putByte((data>>8)&0xFF);
     putByte((data>>0)&0xFF);
-    getByte();	
+    getByte();
     return 0;
-	}
+    }
 
 
 int p18d_mass_erase (void)
     {
     if (verbose>2) flsprintf(stdout,"Mass erase\n");
-	p18d_mass_erase_part(0x800104);
-	p18d_mass_erase_part(0x800204);
-	p18d_mass_erase_part(0x800404);
-	p18d_mass_erase_part(0x800804);
-	/*
-	p18d_mass_erase_part(0x801004);
-	p18d_mass_erase_part(0x802004);
-	p18d_mass_erase_part(0x804004);
-	p18d_mass_erase_part(0x808004);
-	*/
-	p18d_mass_erase_part(0x800004);
-	p18d_mass_erase_part(0x800005);
-	p18d_mass_erase_part(0x800002);
+    p18d_mass_erase_part(0x800104);
+    p18d_mass_erase_part(0x800204);
+    p18d_mass_erase_part(0x800404);
+    p18d_mass_erase_part(0x800804);
+    /*
+    p18d_mass_erase_part(0x801004);
+    p18d_mass_erase_part(0x802004);
+    p18d_mass_erase_part(0x804004);
+    p18d_mass_erase_part(0x808004);
+    */
+    p18d_mass_erase_part(0x800004);
+    p18d_mass_erase_part(0x800005);
+    p18d_mass_erase_part(0x800002);
     return 0;
     }
 
 int p18e_mass_erase (void)
     {
     if (verbose>2) flsprintf(stdout,"Mass erase\n");
-	p18d_mass_erase_part(0x800104);
-	p18d_mass_erase_part(0x800204);
-	p18d_mass_erase_part(0x800404);
-	p18d_mass_erase_part(0x800804);
-	p18d_mass_erase_part(0x801004);
-	p18d_mass_erase_part(0x802004);
-	p18d_mass_erase_part(0x804004);
-	p18d_mass_erase_part(0x808004);
-	p18d_mass_erase_part(0x800004);
-	p18d_mass_erase_part(0x800005);
-	p18d_mass_erase_part(0x800002);
+    p18d_mass_erase_part(0x800104);
+    p18d_mass_erase_part(0x800204);
+    p18d_mass_erase_part(0x800404);
+    p18d_mass_erase_part(0x800804);
+    p18d_mass_erase_part(0x801004);
+    p18d_mass_erase_part(0x802004);
+    p18d_mass_erase_part(0x804004);
+    p18d_mass_erase_part(0x808004);
+    p18d_mass_erase_part(0x800004);
+    p18d_mass_erase_part(0x800005);
+    p18d_mass_erase_part(0x800002);
     return 0;
     }
-    
+
 
 int p18a_write_page (unsigned char * data, int address, unsigned char num)
     {
@@ -793,7 +793,7 @@ int p16c_read_page (unsigned char * data, int address, unsigned char num)
         *data++ = getByte();
         }
 //    for (i=0; i<num; i++) if (verbose>2) flsprintf(stdout,"%2.2x ", data[i]);
-       
+
     return 0;
     }
 
@@ -803,10 +803,10 @@ int p16c_write_page (unsigned char * data, int address, unsigned char num)
     address = address / 2;
     empty = 1;
     for (i=0; i<num; i=i+2)
-		{
-		if 	((data[i]!=0xFF)|(data[i+1]!=0xFF))
-			empty = 0;
-		}
+        {
+        if	((data[i]!=0xFF)|(data[i+1]!=0xFF))
+            empty = 0;
+        }
     if (verbose>2) flsprintf(stdout,"Writing A page of %d bytes at 0x%6.6x\n", num, address);
     if (empty==1)
         {
@@ -899,10 +899,10 @@ int p18q_write_page (unsigned char * data, int address, unsigned char num)
     address = address / 2;
     empty = 1;
     for (i=0; i<num; i=i+2)
-		{
-		if 	((data[i]!=0xFF)|(data[i+1]!=0xFF))
-			empty = 0;
-		}
+        {
+        if	((data[i]!=0xFF)|(data[i+1]!=0xFF))
+            empty = 0;
+        }
     if (verbose>2) flsprintf(stdout,"Writing A page of %d bytes at 0x%6.6x\n", num, address);
     if (empty==1)
         {
@@ -920,17 +920,17 @@ int p18q_write_page (unsigned char * data, int address, unsigned char num)
         putByte(data[i]);
     getByte();
     return 0;
-    }    
+    }
 
 
 int p16c_write_cfg (void)
     {
-	p16c_write_single_cfg(config_bytes[1],config_bytes[0],0x8007);
-	p16c_write_single_cfg(config_bytes[3],config_bytes[2],0x8008);
-	p16c_write_single_cfg(config_bytes[5],config_bytes[4],0x8009);
-	p16c_write_single_cfg(config_bytes[7],config_bytes[6],0x800A);
-	p16c_write_single_cfg(config_bytes[9],config_bytes[8],0x800B);
-	return 0;
+    p16c_write_single_cfg(config_bytes[1],config_bytes[0],0x8007);
+    p16c_write_single_cfg(config_bytes[3],config_bytes[2],0x8008);
+    p16c_write_single_cfg(config_bytes[5],config_bytes[4],0x8009);
+    p16c_write_single_cfg(config_bytes[7],config_bytes[6],0x800A);
+    p16c_write_single_cfg(config_bytes[9],config_bytes[8],0x800B);
+    return 0;
     }
 
 
@@ -958,16 +958,16 @@ int prog_enter_progmode (void)
     {
     if (verbose>2) flsprintf(stdout,"Entering programming mode\n");
     if (chip_family==CF_P16F_A) putByte(0x01);
-    else 	if (chip_family==CF_P16F_B) putByte(0x01);
-    else 	if (chip_family==CF_P16F_D) putByte(0x01);
-    else 	if (chip_family==CF_P18F_A) putByte(0x10);
-    else 	if (chip_family==CF_P18F_B) putByte(0x10);
-    else 	if (chip_family==CF_P18F_D) putByte(0x10);
-    else 	if (chip_family==CF_P18F_E) putByte(0x10);
-    else 	if (chip_family==CF_P16F_C) putByte(0x40);
-    else 	if (chip_family==CF_P18F_F) putByte(0x40);
-    else 	if (chip_family==CF_P18F_Q) putByte(0x40);
-    else 	if (chip_family==CF_P18F_Qxx) putByte(0x40);
+    else if (chip_family==CF_P16F_B) putByte(0x01);
+    else if (chip_family==CF_P16F_D) putByte(0x01);
+    else if (chip_family==CF_P18F_A) putByte(0x10);
+    else if (chip_family==CF_P18F_B) putByte(0x10);
+    else if (chip_family==CF_P18F_D) putByte(0x10);
+    else if (chip_family==CF_P18F_E) putByte(0x10);
+    else if (chip_family==CF_P16F_C) putByte(0x40);
+    else if (chip_family==CF_P18F_F) putByte(0x40);
+    else if (chip_family==CF_P18F_Q) putByte(0x40);
+    else if (chip_family==CF_P18F_Qxx) putByte(0x40);
     putByte(0x00);
     getByte();
     return 0;
@@ -986,12 +986,12 @@ int prog_get_device_id (void)
     {
     unsigned char mem_str[10];
     unsigned int devid;
-	if (verbose>2) flsprintf(stdout,"getting ID for family %d\n",chip_family);
+    if (verbose>2) flsprintf(stdout,"getting ID for family %d\n",chip_family);
     if ((chip_family==CF_P16F_A)|(chip_family==CF_P16F_B)|(chip_family==CF_P16F_D))
         return p16a_get_devid();
     if ((chip_family==CF_P16F_C))
         return p16c_get_devid();
-    else 	if ((chip_family==CF_P18F_A)|(chip_family==CF_P18F_B)|(chip_family==CF_P18F_D)|(chip_family==CF_P18F_E))
+    else if ((chip_family==CF_P18F_A)|(chip_family==CF_P18F_B)|(chip_family==CF_P18F_D)|(chip_family==CF_P18F_E))
         {
         p18a_read_page((unsigned char *)&mem_str, 0x3FFFFE, 2);
         devid = (((unsigned int)(mem_str[1]))<<8) + (((unsigned int)(mem_str[0]))<<0);
@@ -999,13 +999,13 @@ int prog_get_device_id (void)
         return devid;
         }
     if ((chip_family==CF_P18F_F)|(chip_family==CF_P18F_Q)|(chip_family==CF_P18F_Qxx))
-		{
-		p16c_read_page(mem_str, 0x3FFFFE*2,2);
+        {
+        p16c_read_page(mem_str, 0x3FFFFE*2,2);
         devid = (((unsigned int)(mem_str[1]))<<8) + (((unsigned int)(mem_str[0]))<<0);
         devid = devid & devid_mask;
-        return devid;		
-		}
-        
+        return devid;
+        }
+
     return 0;
     }
 
@@ -1035,7 +1035,7 @@ int parse_hex (char * filename, unsigned char * progmem, unsigned char * config)
     if (chip_family==CF_P16F_B) p16_cfg = 1;
     if (chip_family==CF_P16F_C) p16_cfg = 1;
     if (chip_family==CF_P16F_D) p16_cfg = 1;
-    
+
     if (verbose>2) printf ("File open\n");
     while ((read =  getlinex(&line, &len, sf)) != -1)
         {
@@ -1143,9 +1143,9 @@ int main(int argc, char *argv[])
     prog_enter_progmode();									//enter programming mode and probe the target
     i = prog_get_device_id();
     if (i==devid_expected)
-		{
+        {
         if (verbose>0) printf ("Device ID: %4.4x \n", i);
-		}
+        }
     else
         {
         printf ("Wrong device ID: %4.4x, expected: %4.4x\n", i,devid_expected);
@@ -1168,7 +1168,7 @@ int main(int argc, char *argv[])
             if (chip_family==CF_P18F_E)
                 p18e_mass_erase();
             if ((chip_family==CF_P18F_F)|(chip_family==CF_P18F_Q))
-                p16c_mass_erase();                
+                p16c_mass_erase();
             if (chip_family==CF_P18F_Qxx)
                 p18qxx_mass_erase();
             if (verbose>0) printf ("Programming FLASH (%d B in %d pages per %d bytes): \n",flash_size,flash_size/page_size,page_size);
@@ -1177,20 +1177,20 @@ int main(int argc, char *argv[])
                 {
                 if (is_empty(progmem+i,page_size)==0)
                     {
-					if ((chip_family==CF_P18F_D)|(chip_family==CF_P18F_E))
-						p18d_write_page(progmem+i,i,page_size);
-					else if (chip_family==CF_P18F_F)
-						p16c_write_page(progmem+i,i*2,page_size);						
-					else if ((chip_family==CF_P18F_Q)|(chip_family==CF_P18F_Qxx))
-						p18q_write_page(progmem+i,i*2,page_size);						
-					else
-						p18a_write_page(progmem+i,i,page_size);
+                    if ((chip_family==CF_P18F_D)|(chip_family==CF_P18F_E))
+                        p18d_write_page(progmem+i,i,page_size);
+                    else if (chip_family==CF_P18F_F)
+                        p16c_write_page(progmem+i,i*2,page_size);
+                    else if ((chip_family==CF_P18F_Q)|(chip_family==CF_P18F_Qxx))
+                        p18q_write_page(progmem+i,i*2,page_size);
+                    else
+                        p18a_write_page(progmem+i,i,page_size);
                     pages_performed++;
-                    if (verbose>1) 
-						{
-						printf ("#");
-						fflush(stdout);
-						}
+                    if (verbose>1)
+                        {
+                        printf ("#");
+                        fflush(stdout);
+                        }
                     }
                 else if (verbose>2)
                     {
@@ -1198,11 +1198,11 @@ int main(int argc, char *argv[])
                     fflush(stdout);
                     }
                 }
-				
+
             if (verbose>0) printf ("\n%d pages programmed\n",pages_performed);
             if (verbose>0) printf ("Programming config\n");
             for (i=0; i<config_size; i=i+2) //write config bytes for PIC18Fxxxx and 18FxxKxx devices
-				{
+                {
                 if (chip_family==CF_P18F_A) p18a_write_cfg(config_bytes[i],config_bytes[i+1],0x300000+i);
                 if (chip_family==CF_P18F_D) p18d_write_cfg(config_bytes[i],config_bytes[i+1],0x300000+i);
                 if (chip_family==CF_P18F_E) p18d_write_cfg(config_bytes[i],config_bytes[i+1],0x300000+i);
@@ -1214,8 +1214,8 @@ int main(int argc, char *argv[])
                     if (i+1<config_size)
                         p18q_write_byte_cfg (config_bytes[i+1],0x300000+i+1);
                     }
-				}
-															//for PIC18FxxJxx, config bytes are at the end of FLASH memory
+                }
+                                                            //for PIC18FxxJxx, config bytes are at the end of FLASH memory
             }
         if (verify==1)
             {
@@ -1233,10 +1233,10 @@ int main(int argc, char *argv[])
                     }
                 else
                     {
-					if ((chip_family==CF_P18F_F)|(chip_family==CF_P18F_Q)|(chip_family==CF_P18F_Qxx))
-						p16c_read_page(tdat,i*2,page_size);		
-					else
-						p18a_read_page(tdat,i,page_size);
+                    if ((chip_family==CF_P18F_F)|(chip_family==CF_P18F_Q)|(chip_family==CF_P18F_Qxx))
+                        p16c_read_page(tdat,i*2,page_size);
+                    else
+                        p18a_read_page(tdat,i,page_size);
                     pages_performed++;
                     if (verbose>3) printf ("Verifying page at 0x%4.4X\n",i);
                     if (verbose>1)
@@ -1256,26 +1256,26 @@ int main(int argc, char *argv[])
                         }
                     }
                 }
-            if (verbose>0) printf ("\n%d pages verified\n",pages_performed);        
+            if (verbose>0) printf ("\n%d pages verified\n",pages_performed);
             if ((chip_family==CF_P18F_F)|(chip_family==CF_P18F_Q))
-				p16c_read_page(tdat,0x300000*2,page_size);	
-			else if (chip_family==CF_P18F_Qxx)
-				p18q_read_cfg(tdat,0x300000,config_size);
-			else
-				p18a_read_page(tdat,0x300000,page_size);
-			
-			if (verbose>0) printf ("Verifying config...");
-			for (i=0; i<config_size; i++) 
-				{
+                p16c_read_page(tdat,0x300000*2,page_size);
+            else if (chip_family==CF_P18F_Qxx)
+                p18q_read_cfg(tdat,0x300000,config_size);
+            else
+                p18a_read_page(tdat,0x300000,page_size);
+
+            if (verbose>0) printf ("Verifying config...");
+            for (i=0; i<config_size; i++)
+                {
                  if (config_bytes[i] != tdat[i])
                     {
                     printf ("Error at 0x%2.2X E:0x%2.2X R:0x%2.2X\n",i,config_bytes[i],tdat[i]);
                     printf ("Exiting now\n");
                     prog_exit_progmode();
                     exit(0);
-					}
-				}
-			if (verbose>0) printf ("OK\n");
+                    }
+                }
+            if (verbose>0) printf ("OK\n");
             }
         }
     else
@@ -1328,26 +1328,26 @@ int main(int argc, char *argv[])
                 }
             if (verbose>0) printf ("\n");
             if (verbose>0) printf ("Verifying config\n");
-			if ((chip_family==CF_P16F_A)|(chip_family==CF_P16F_B)|(chip_family==CF_P16F_D))
-				{
-				config = p16a_get_config(7);
-				econfig = (((unsigned int)(file_image[2*0x8007]))<<0) + (((unsigned int)(file_image[2*0x8007+1]))<<8);
-				if (config==econfig)
-					{
-					if (verbose>1) printf ("config 1 OK: %4.4X\n",config);
-					}
-				else	printf ("config 1 error: E:0x%4.4X R:0x%4.4X\n",config,econfig);
-				config = p16a_get_config(8);
-				econfig = (((unsigned int)(file_image[2*0x8008]))<<0) + (((unsigned int)(file_image[2*0x8008+1]))<<8);
-				if (config==econfig)
-					{
-					if (verbose>1) printf ("config 2 OK: %4.4X\n",config);
-					}
-				else	printf ("config 2 error: E:0x%4.4X R:0x%4.4X\n",config,econfig);
-				}
-			if (chip_family==CF_P16F_C)
-				{
-				p16c_read_page(tdat,0x8007*2,page_size);
+            if ((chip_family==CF_P16F_A)|(chip_family==CF_P16F_B)|(chip_family==CF_P16F_D))
+                {
+                config = p16a_get_config(7);
+                econfig = (((unsigned int)(file_image[2*0x8007]))<<0) + (((unsigned int)(file_image[2*0x8007+1]))<<8);
+                if (config==econfig)
+                    {
+                    if (verbose>1) printf ("config 1 OK: %4.4X\n",config);
+                    }
+                else	printf ("config 1 error: E:0x%4.4X R:0x%4.4X\n",config,econfig);
+                config = p16a_get_config(8);
+                econfig = (((unsigned int)(file_image[2*0x8008]))<<0) + (((unsigned int)(file_image[2*0x8008+1]))<<8);
+                if (config==econfig)
+                    {
+                    if (verbose>1) printf ("config 2 OK: %4.4X\n",config);
+                    }
+                else	printf ("config 2 error: E:0x%4.4X R:0x%4.4X\n",config,econfig);
+                }
+            if (chip_family==CF_P16F_C)
+                {
+                p16c_read_page(tdat,0x8007*2,page_size);
                 for (j=0; j<10; j++)
                     {
                     if (config_bytes[j] != tdat[j])
@@ -1358,7 +1358,7 @@ int main(int argc, char *argv[])
                         }
                     }
 
-				}
+                }
             }
         }
     prog_exit_progmode();

--- a/sw/pp3.c
+++ b/sw/pp3.c
@@ -1029,7 +1029,10 @@ int parse_hex (char * filename, unsigned char * progmem, unsigned char * config)
     if (verbose>2) printf ("Opening filename %s \n", filename);
     FILE* sf = fopen(filename, "r");
     if (sf==0)
+        {
+        fprintf (stderr,"Can't open hex file %s\n",filename);
         return -1;
+        }
     line_address_offset = 0;
     if (chip_family==CF_P16F_A) p16_cfg = 1;
     if (chip_family==CF_P16F_B) p16_cfg = 1;
@@ -1125,7 +1128,12 @@ int main(int argc, char *argv[])
     char* filename=argv[argc-1];
     pm_point = (unsigned char *)(&progmem);
     cm_point = (unsigned char *)(&config_bytes);
-    parse_hex(filename,pm_point,cm_point);					//parse and write content of hex file into buffers
+    if (program==1 && parse_hex(filename,pm_point,cm_point))
+        //parse and write content of hex file into buffers
+        {
+        fprintf (stderr,"Failed to read input file.\n");
+        abort ();
+        }
 
     //now this is ugly kludge
     //my original programmer expected only file_image holding the image of memory to be programmed


### PR DESCRIPTION
I've added Arduino Leonardo support.

With this modification, the PIC programmer runs on the Arduino Leonardo as well as on the Arduino UNO.
The ICSP shield for UNO can be used for Leonardo.
The build method and usage are the same as UNO's.

I wrote to PIC 18F47Q43 on the EMUZ80 with Arduino UNO and Arduino Leonardo in the following procedure. I confirmed that it worked as expected.
```
% ./pp3 -c /dev/tty.usbmodem1444201 -s 1700 -p -n -t 18f47q43
PP programmer for Q43/Q8x, version 0.99
Sleeping for 1700 ms while arduino bootloader expires
Device ID: 74a0

% ./pp3 -c /dev/tty.usbmodem1444201 -s 1700 -v 2 -t 18f47q43 SuperMEZ80_6MHz_Q43.hex
Found database match 18f47q43,131072,128,74a0,ffff,CF_P18F_Q43
PP programmer for Q43/Q8x, version 0.99
Opening serial port
Sleeping for 1700 ms while arduino bootloader expires
Device ID: 74a0
Programming FLASH (131072 B in 1024 pages per 128 bytes):
#########################################################################
73 pages programmed
Programming config
Verifying FLASH (131072 B in 1024 pages per 128 bytes):
#########################################################################
73 pages verified
Verifying config...OK
```